### PR TITLE
Resolve vulnerabilities in azul-pycharm image (DataBiosphere/azul-private#94)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker
 on: push
 
 env:
-  azul_docker_pycharm_version: 2  # increment this to update the OS packages
+  azul_docker_pycharm_version: 3  # increment this to update the OS packages
 
 jobs:
   build:


### PR DESCRIPTION
This PR replaces PR https://github.com/DataBiosphere/azul-docker-pycharm/pull/2 which was closed due to a non-standard branch name