### PR TITLE
Resolve vulnerabilities in azul-pycharm image (DataBiosphere/azul-private#94)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,5 +40,10 @@ jobs:
             azul_docker_pycharm_version=${{ env.azul_docker_pycharm_version }}
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' && steps.vars.outputs.branch != 'master' }}
+          push: >
+            ${{
+            github.event_name != 'pull_request'
+            && steps.vars.outputs.branch != 'master'
+            && endsWith(steps.vars.outputs.branch, '-PR') != true
+            }}
           tags: ${{ vars.DOCKERHUB_REPOSITORY }}:${{ steps.vars.outputs.branch }}-${{ env.azul_docker_pycharm_version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker
 on: push
 
 env:
-  azul_docker_pycharm_version: 2  # increment this to update the OS packages
+  azul_docker_pycharm_version: 3  # increment this to update the OS packages
 
 jobs:
   build:
@@ -44,6 +44,6 @@ jobs:
             ${{
             github.event_name != 'pull_request'
             && steps.vars.outputs.branch != 'master'
-            && endsWith(steps.vars.outputs.branch, '-PR') != true
+            && !endsWith(steps.vars.outputs.branch, '-PR')
             }}
           tags: ${{ vars.DOCKERHUB_REPOSITORY }}:${{ steps.vars.outputs.branch }}-${{ env.azul_docker_pycharm_version }}


### PR DESCRIPTION
This PR replaces PR https://github.com/DataBiosphere/azul-docker-pycharm/pull/3 which was closed due to problems with its branch name `2022.3.3-3` resulting in an undesired docker hub tag `2022.3.3-3-3`